### PR TITLE
Add Section4 navigation and draft UI tweak

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -11,7 +11,7 @@ from utils import allowed_file
 def register_routes(app):
     @app.route('/')
     def index():
-        return redirect(url_for('learner_access_form'))
+        return redirect(url_for('section4'))
 
     @app.route('/learner-access', methods=['GET', 'POST'])
     def learner_access_form():
@@ -270,4 +270,28 @@ def register_routes(app):
             as_attachment=True,
             download_name=f'PSEF_Evidence_Files_{entry_id}.zip'
         )
+
+    @app.route('/section4')
+    def section4():
+        return render_template('section4.html')
+
+    @app.route('/section4/1')
+    def section4_1():
+        return render_template('section4_1.html')
+
+    @app.route('/section4/2')
+    def section4_2():
+        return render_template('section4_2.html')
+
+    @app.route('/section4/3')
+    def section4_3():
+        return render_template('section4_3.html')
+
+    @app.route('/section4/4')
+    def section4_4():
+        return render_template('section4_4.html')
+
+    @app.route('/section4/5')
+    def section4_5():
+        return render_template('section4_5.html')
 

--- a/templates/learner_access.html
+++ b/templates/learner_access.html
@@ -129,7 +129,7 @@
         </div>
 
         <!-- Draft Description Field -->
-        <div style="margin-top: 1rem;">
+        <div id="draft_desc_container" style="margin-top: 1rem; display: {{ 'block' if draft_description else 'none' }};">
             <label for="draft_description">
                 Draft Description (to help you identify this draft later):
             </label>
@@ -137,7 +137,7 @@
                    value="{{ draft_description }}">
         </div>
 
-        <button type="submit" name="action" value="save">💾 Save as Draft</button>
+        <button type="submit" name="action" value="save" id="save_draft_btn">💾 Save as Draft</button>
         <button type="submit" name="action" value="submit">✅ Submit</button>
     </form>
 </div>
@@ -156,6 +156,8 @@
 <script>
     const textarea = document.getElementById('programme_description');
     const wordCount = document.getElementById('word_count');
+    const saveDraftBtn = document.getElementById('save_draft_btn');
+    const draftContainer = document.getElementById('draft_desc_container');
 
     textarea.addEventListener('input', () => {
         const words = textarea.value.trim().split(/\s+/).filter(Boolean);
@@ -163,6 +165,13 @@
         if (words.length > 500) {
             textarea.value = words.slice(0, 500).join(' ');
             wordCount.textContent = "(500/500 words)";
+        }
+    });
+
+    saveDraftBtn.addEventListener('click', (e) => {
+        if (draftContainer.style.display === 'none') {
+            e.preventDefault();
+            draftContainer.style.display = 'block';
         }
     });
 </script>

--- a/templates/section4.html
+++ b/templates/section4.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="form-container">
+    <h1>Section 4</h1>
+    <p>Select a subsection to continue:</p>
+    <ul>
+        <li><a href="{{ url_for('section4_1') }}">Section 4.1</a></li>
+        <li><a href="{{ url_for('section4_2') }}">Section 4.2</a></li>
+        <li><a href="{{ url_for('section4_3') }}">Section 4.3</a></li>
+        <li><a href="{{ url_for('section4_4') }}">Section 4.4</a></li>
+        <li><a href="{{ url_for('section4_5') }}">Section 4.5</a></li>
+    </ul>
+</div>
+{% endblock %}

--- a/templates/section4_1.html
+++ b/templates/section4_1.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="form-container">
+    <h1>Section 4.1</h1>
+    <p>Placeholder for Section 4.1 content.</p>
+    <div style="margin-top:1rem;">
+        <a href="{{ url_for('section4') }}"><button>&laquo; Back</button></a>
+        <a href="{{ url_for('section4_2') }}"><button>Next &raquo;</button></a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/section4_2.html
+++ b/templates/section4_2.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="form-container">
+    <h1>Section 4.2</h1>
+    <p>Placeholder for Section 4.2 content.</p>
+    <div style="margin-top:1rem;">
+        <a href="{{ url_for('section4_1') }}"><button>&laquo; Back</button></a>
+        <a href="{{ url_for('section4_3') }}"><button>Next &raquo;</button></a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/section4_3.html
+++ b/templates/section4_3.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="form-container">
+    <h1>Section 4.3</h1>
+    <p>Placeholder for Section 4.3 content.</p>
+    <div style="margin-top:1rem;">
+        <a href="{{ url_for('section4_2') }}"><button>&laquo; Back</button></a>
+        <a href="{{ url_for('section4_4') }}"><button>Next &raquo;</button></a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/section4_4.html
+++ b/templates/section4_4.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="form-container">
+    <h1>Section 4.4</h1>
+    <p>Placeholder for Section 4.4 content.</p>
+    <div style="margin-top:1rem;">
+        <a href="{{ url_for('section4_3') }}"><button>&laquo; Back</button></a>
+        <a href="{{ url_for('section4_5') }}"><button>Next &raquo;</button></a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/section4_5.html
+++ b/templates/section4_5.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="form-container">
+    <h1>Section 4.5</h1>
+    <p>Placeholder for Section 4.5 content.</p>
+    <div style="margin-top:1rem;">
+        <a href="{{ url_for('section4_4') }}"><button>&laquo; Back</button></a>
+        <a href="{{ url_for('section4') }}"><button>Home</button></a>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- redirect home page to new Section 4 landing page
- add routes and templates for section4 and subsections
- show draft description input only when saving a draft

## Testing
- `ruff check .` *(fails: numerous style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6865bb17d8388324a39293a7a71f50e7